### PR TITLE
Update search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Search image by URL with Google, Bing Yandex and TinEye reverse image search res
 ```
 python ris.py
 Image URL: https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
-Google Result: https://www.google.com/searchbyimage?image_url=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
-Yandex Result: https://yandex.com/images/search?source=collections&url=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg&rpt=imageview
-TinEye Result: https://www.tineye.com/search/?&url=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
-Bing Result: https://www.bing.com/images/searchbyimage?FORM=IRSBIQ&cbir=sbi&imgurl=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
+Google Result: https://www.google.com/searchbyimage?client=app&image_url=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
+Yandex Result: https://yandex.com/images/search?rpt=imageview&url=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
+TinEye Result: https://tineye.com/search?url=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
+Bing Result: https://www.bing.com/images/searchbyimage?cbir=sbi&imgurl=https://i1.sndcdn.com/avatars-000248291936-634zqi-t500x500.jpg
 ```
 
 # Other reverse image search engines

--- a/ris.py
+++ b/ris.py
@@ -16,10 +16,10 @@ def main():
         while True:
             image_url = input("Image URL: ")
             results = {}
-            results["Google"] = f"https://www.google.com/searchbyimage?image_url={image_url}"
-            results["Yandex"] = f"https://yandex.com/images/search?source=collections&url={image_url}&rpt=imageview"
-            results["TinEye"] = f"https://www.tineye.com/search/?&url={image_url}"
-            results["Bing"] = f"https://www.bing.com/images/searchbyimage?FORM=IRSBIQ&cbir=sbi&imgurl={image_url}"
+            results["Google"] = f"https://www.google.com/searchbyimage?client=app&image_url={image_url}"
+            results["Yandex"] = f"https://yandex.com/images/search?rpt=imageview&url={image_url}"
+            results["TinEye"] = f"https://tineye.com/search?url={image_url}"
+            results["Bing"] = f"https://www.bing.com/images/searchbyimage?cbir=sbi&imgurl={image_url}"
             for result in results:
                 print(f"{C_BLUE}{result}: {C_RESET}{results[result]}")
             print(f"\r\n")


### PR DESCRIPTION
- *Google*: add [required](https://webapps.stackexchange.com/questions/167766/reverse-google-image-search-via-url-after-2022-switch-to-google-lens) `client=app` parameter after 2022 switch to Google Lens
- *Yandex*: remove unnecessary `source=collections` parameter
- *TinyEye*: remove unnecessary `www` (site doesn't perform canonical redirect, so there's no secondary DNS request), `/` and `&`
- *Bing*: remove unnecessary `FORM=IRSBIQ` parameter
